### PR TITLE
Provide a CDI version of MetricsConfiguration

### DIFF
--- a/src/main/java/org/jboss/pnc/pncmetrics/MetricsCDIConfiguration.java
+++ b/src/main/java/org/jboss/pnc/pncmetrics/MetricsCDIConfiguration.java
@@ -1,0 +1,239 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.pnc.pncmetrics;
+
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.graphite.Graphite;
+import com.codahale.metrics.graphite.GraphiteReporter;
+import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
+import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
+
+import io.github.mweirauch.metrics.jvm.extras.FileDescriptorCountGauge;
+import io.github.mweirauch.metrics.jvm.extras.ProcessMemoryUsageGaugeSet;
+import io.github.mweirauch.metrics.jvm.extras.UptimeGauge;
+import lombok.Getter;
+import org.jboss.pnc.pncmetrics.exceptions.NoPropertyException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+@ApplicationScoped
+public class MetricsCDIConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(MetricsCDIConfiguration.class);
+
+    public static final String METRIC_JVM_MEMORY = "jvm.memory";
+    public static final String METRIC_JVM_GARBAGE = "jvm.garbage";
+    public static final String METRIC_JVM_THREADS = "jvm.threads";
+    public static final String METRIC_JVM_CLASSLOADING = "jvm.classloading";
+
+    public static final String METRIC_JVM_PROCESS_MEMORY = "jvm.process.mem";
+    public static final String METRIC_JVM_PROCESS_FDS_COUNT = "jvm.process.fds.count";
+    public static final String METRIC_JVM_PROCESS_UPTIME = "jvm.process.uptime";
+
+    public static final String GRAPHITE_SERVER_KEY = "metrics_graphite_server";
+    public static final String GRAPHITE_PORT_KEY = "metrics_graphite_port";
+    public static final String GRAPHITE_PREFIX_KEY = "metrics_graphite_prefix";
+
+    // The interval is in seconds
+    public static final String GRAPHITE_INTERVAL_KEY = "metrics_graphite_interval";
+    public static final String GRAPHITE_PROCESS_INTERVAL_KEY = "metrics_graphite_process_interval";
+
+    public static final int DEFAULT_GRAPHITE_INTERVAL = 60;
+    public static final int DEFAULT_GRAPHITE_PROCESS_INTERVAL = 15;
+
+    @Getter
+    private MetricRegistry metricRegistry;
+
+    @Getter
+    private MetricRegistry processMetricRegistry;
+
+    @Getter
+    private GaugeMetric gaugeMetric;
+
+    @PostConstruct
+    public void init() {
+
+        metricRegistry = new MetricRegistry();
+        gaugeMetric = new GaugeMetric(metricRegistry);
+
+        processMetricRegistry = new MetricRegistry();
+
+        monitorJvmMetrics();
+        monitorJvmProcessMetrics();
+        setupGraphiteReporters();
+
+    }
+
+    /**
+     * If propertyName has no value (either specified in system property or environment property), then just return the
+     * default value. System property value has priority over environment property value.
+     * <p>
+     * If value can't be parsed, just return the default value.
+     *
+     * @param propertyName property name to check the value
+     * @param description description to print in case value can't be parsed as an integer
+     * @return value from property, or throws NoPropertyException if property not specified
+     * @throws NoPropertyException if property not specified on system or env value
+     */
+    public String getValueFromProperty(String propertyName, String description) throws NoPropertyException {
+
+        String value;
+
+        String valueSys = System.getProperty(propertyName);
+        String valueEnv = System.getenv(propertyName);
+
+        if (valueSys != null) {
+            value = valueSys;
+        } else if (valueEnv != null) {
+            value = valueEnv;
+        } else {
+            throw new NoPropertyException("Property '" + propertyName + "' not specified");
+        }
+
+        logger.info("Updated " + description + " to: " + value);
+
+        return value;
+    }
+
+    /**
+     * Add metrics for JVM. Already provided by metrics-jvm
+     */
+    private void monitorJvmMetrics() {
+
+        logger.info("Registering JVM metrics");
+
+        metricRegistry.register(METRIC_JVM_GARBAGE, new GarbageCollectorMetricSet());
+        metricRegistry.register(METRIC_JVM_MEMORY, new MemoryUsageGaugeSet());
+        metricRegistry.register(METRIC_JVM_THREADS, new ThreadStatesGaugeSet());
+        metricRegistry.register(METRIC_JVM_CLASSLOADING, new ClassLoadingGaugeSet());
+    }
+
+    /**
+     * Add metrics for JVM processes. Additional metrics complementing metrics-jvm
+     */
+    private void monitorJvmProcessMetrics() {
+
+        logger.info("Registering JVM process metrics");
+
+        processMetricRegistry.register(METRIC_JVM_PROCESS_MEMORY, new ProcessMemoryUsageGaugeSet());
+        processMetricRegistry.register(METRIC_JVM_PROCESS_FDS_COUNT, new FileDescriptorCountGauge());
+        processMetricRegistry.register(METRIC_JVM_PROCESS_UPTIME, new UptimeGauge());
+    }
+
+    /**
+     * Read system or environment variable to know to which Graphite server to report data to.
+     *
+     * If any of the required variables are not specified, abandon the setup and warn the user.
+     *
+     */
+    private void setupGraphiteReporters() {
+
+        int graphiteInterval = DEFAULT_GRAPHITE_INTERVAL;
+        int graphiteProcessInterval = DEFAULT_GRAPHITE_PROCESS_INTERVAL;
+
+        try {
+
+            graphiteInterval = Integer
+                    .parseInt(getValueFromProperty(GRAPHITE_INTERVAL_KEY, "Graphite Interval reporting"));
+
+        } catch (NumberFormatException e) {
+
+            // thrown because we couldn't parse the interval as a number
+            logger.warn(
+                    "Could not parse Graphite interval! Using default value of {} seconds instead",
+                    DEFAULT_GRAPHITE_INTERVAL);
+
+        } catch (NoPropertyException e) {
+            // If we're here that property is not specified. Just continue using the default
+        }
+
+        try {
+
+            graphiteProcessInterval = Integer.parseInt(
+                    getValueFromProperty(GRAPHITE_PROCESS_INTERVAL_KEY, "Graphite Process Interval reporting"));
+
+        } catch (NumberFormatException e) {
+
+            // thrown because we couldn't parse the interval as a number
+            logger.warn(
+                    "Could not parse Graphite process interval! Using default value of {} seconds instead",
+                    DEFAULT_GRAPHITE_PROCESS_INTERVAL);
+
+        } catch (NoPropertyException e) {
+            // If we're here that property is not specified. Just continue using the default
+        }
+
+        try {
+
+            String graphiteServer = getValueFromProperty(GRAPHITE_SERVER_KEY, "Graphite Server URL");
+            int graphitePort = Integer.parseInt(getValueFromProperty(GRAPHITE_PORT_KEY, "Graphite Port"));
+            String graphitePrefix = getValueFromProperty(GRAPHITE_PREFIX_KEY, "Graphite Prefix");
+
+            startGraphiteReporter(metricRegistry, graphiteServer, graphitePort, graphitePrefix, graphiteInterval);
+            startGraphiteReporter(
+                    processMetricRegistry,
+                    graphiteServer,
+                    graphitePort,
+                    graphitePrefix,
+                    graphiteProcessInterval);
+
+        } catch (NumberFormatException e) {
+
+            // thrown because it couldn't parse graphitePort
+            logger.warn("Could not parse Graphite port! Aborting reporting data to Graphite", e);
+
+        } catch (NoPropertyException e) {
+
+            logger.warn("Could not find property required to setup Graphite reporting! Reason: {}", e.getMessage());
+
+        }
+    }
+
+    /**
+     * Reporter of metrics to a Graphite server
+     *
+     * @param host Graphite server
+     * @param port Graphite port (usually 2003)
+     * @param prefix Prefix to use as a namespace for our logs
+     * @param interval interval at which to report metrics to Graphite in seconds
+     */
+    private void startGraphiteReporter(MetricRegistry registry, String host, int port, String prefix, int interval) {
+
+        logger.info("Setting up Graphite reporter");
+
+        Graphite graphite = new Graphite(new InetSocketAddress(host, port));
+
+        GraphiteReporter reporter = GraphiteReporter.forRegistry(registry)
+                .prefixedWith(prefix)
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .filter(MetricFilter.ALL)
+                .build(graphite);
+
+        reporter.start(interval, TimeUnit.SECONDS);
+    }
+
+}

--- a/src/main/java/org/jboss/pnc/pncmetrics/MetricsConfiguration.java
+++ b/src/main/java/org/jboss/pnc/pncmetrics/MetricsConfiguration.java
@@ -1,241 +1,36 @@
-/**
- * JBoss, Home of Professional Open Source.
- * Copyright 2014 Red Hat, Inc., and individual contributors
- * as indicated by the @author tags.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.jboss.pnc.pncmetrics;
 
-import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.graphite.Graphite;
-import com.codahale.metrics.graphite.GraphiteReporter;
-import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
-import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
-import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
-import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
-
-import io.github.mweirauch.metrics.jvm.extras.FileDescriptorCountGauge;
-import io.github.mweirauch.metrics.jvm.extras.ProcessMemoryUsageGaugeSet;
-import io.github.mweirauch.metrics.jvm.extras.UptimeGauge;
 import lombok.Getter;
 import org.jboss.pnc.pncmetrics.exceptions.NoPropertyException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
-import java.net.InetSocketAddress;
-import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
 
+/**
+ * used to inject in EJBs
+ */
 @Singleton
 @Startup
 public class MetricsConfiguration {
 
-    private static final Logger logger = LoggerFactory.getLogger(MetricsConfiguration.class);
+    @Inject
+    private MetricsCDIConfiguration metricsCDIConfiguration;
 
-    public static final String METRIC_JVM_MEMORY = "jvm.memory";
-    public static final String METRIC_JVM_GARBAGE = "jvm.garbage";
-    public static final String METRIC_JVM_THREADS = "jvm.threads";
-    public static final String METRIC_JVM_CLASSLOADING = "jvm.classloading";
-
-    public static final String METRIC_JVM_PROCESS_MEMORY = "jvm.process.mem";
-    public static final String METRIC_JVM_PROCESS_FDS_COUNT = "jvm.process.fds.count";
-    public static final String METRIC_JVM_PROCESS_UPTIME = "jvm.process.uptime";
-
-    public static final String GRAPHITE_SERVER_KEY = "metrics_graphite_server";
-    public static final String GRAPHITE_PORT_KEY = "metrics_graphite_port";
-    public static final String GRAPHITE_PREFIX_KEY = "metrics_graphite_prefix";
-
-    // The interval is in seconds
-    public static final String GRAPHITE_INTERVAL_KEY = "metrics_graphite_interval";
-    public static final String GRAPHITE_PROCESS_INTERVAL_KEY = "metrics_graphite_process_interval";
-
-    public static final int DEFAULT_GRAPHITE_INTERVAL = 60;
-    public static final int DEFAULT_GRAPHITE_PROCESS_INTERVAL = 15;
-
-    @Getter
-    private MetricRegistry metricRegistry;
-
-    @Getter
-    private MetricRegistry processMetricRegistry;
-
-    @Getter
-    private GaugeMetric gaugeMetric;
-
-    @PostConstruct
-    public void init() {
-
-        metricRegistry = new MetricRegistry();
-        gaugeMetric = new GaugeMetric(metricRegistry);
-
-        processMetricRegistry = new MetricRegistry();
-
-        monitorJvmMetrics();
-        monitorJvmProcessMetrics();
-        setupGraphiteReporters();
-
+    public MetricRegistry getMetricRegistry() {
+        return metricsCDIConfiguration.getMetricRegistry();
     }
 
-    /**
-     * If propertyName has no value (either specified in system property or environment property), then just return the
-     * default value. System property value has priority over environment property value.
-     * <p>
-     * If value can't be parsed, just return the default value.
-     *
-     * @param propertyName property name to check the value
-     * @param description description to print in case value can't be parsed as an integer
-     * @return value from property, or throws NoPropertyException if property not specified
-     * @throws NoPropertyException if property not specified on system or env value
-     */
+    public MetricRegistry getProcessMetricRegistry() {
+        return metricsCDIConfiguration.getProcessMetricRegistry();
+    }
+
+    public GaugeMetric getGaugeMetric() {
+        return metricsCDIConfiguration.getGaugeMetric();
+    }
+
     public String getValueFromProperty(String propertyName, String description) throws NoPropertyException {
-
-        String value;
-
-        String valueSys = System.getProperty(propertyName);
-        String valueEnv = System.getenv(propertyName);
-
-        if (valueSys != null) {
-            value = valueSys;
-        } else if (valueEnv != null) {
-            value = valueEnv;
-        } else {
-            throw new NoPropertyException("Property '" + propertyName + "' not specified");
-        }
-
-        logger.info("Updated " + description + " to: " + value);
-
-        return value;
+        return metricsCDIConfiguration.getValueFromProperty(propertyName, description);
     }
-
-    /**
-     * Add metrics for JVM. Already provided by metrics-jvm
-     */
-    private void monitorJvmMetrics() {
-
-        logger.info("Registering JVM metrics");
-
-        metricRegistry.register(METRIC_JVM_GARBAGE, new GarbageCollectorMetricSet());
-        metricRegistry.register(METRIC_JVM_MEMORY, new MemoryUsageGaugeSet());
-        metricRegistry.register(METRIC_JVM_THREADS, new ThreadStatesGaugeSet());
-        metricRegistry.register(METRIC_JVM_CLASSLOADING, new ClassLoadingGaugeSet());
-    }
-
-    /**
-     * Add metrics for JVM processes. Additional metrics complementing metrics-jvm
-     */
-    private void monitorJvmProcessMetrics() {
-
-        logger.info("Registering JVM process metrics");
-
-        processMetricRegistry.register(METRIC_JVM_PROCESS_MEMORY, new ProcessMemoryUsageGaugeSet());
-        processMetricRegistry.register(METRIC_JVM_PROCESS_FDS_COUNT, new FileDescriptorCountGauge());
-        processMetricRegistry.register(METRIC_JVM_PROCESS_UPTIME, new UptimeGauge());
-    }
-
-    /**
-     * Read system or environment variable to know to which Graphite server to report data to.
-     *
-     * If any of the required variables are not specified, abandon the setup and warn the user.
-     *
-     */
-    private void setupGraphiteReporters() {
-
-        int graphiteInterval = DEFAULT_GRAPHITE_INTERVAL;
-        int graphiteProcessInterval = DEFAULT_GRAPHITE_PROCESS_INTERVAL;
-
-        try {
-
-            graphiteInterval = Integer
-                    .parseInt(getValueFromProperty(GRAPHITE_INTERVAL_KEY, "Graphite Interval reporting"));
-
-        } catch (NumberFormatException e) {
-
-            // thrown because we couldn't parse the interval as a number
-            logger.warn(
-                    "Could not parse Graphite interval! Using default value of {} seconds instead",
-                    DEFAULT_GRAPHITE_INTERVAL);
-
-        } catch (NoPropertyException e) {
-            // If we're here that property is not specified. Just continue using the default
-        }
-
-        try {
-
-            graphiteProcessInterval = Integer.parseInt(
-                    getValueFromProperty(GRAPHITE_PROCESS_INTERVAL_KEY, "Graphite Process Interval reporting"));
-
-        } catch (NumberFormatException e) {
-
-            // thrown because we couldn't parse the interval as a number
-            logger.warn(
-                    "Could not parse Graphite process interval! Using default value of {} seconds instead",
-                    DEFAULT_GRAPHITE_PROCESS_INTERVAL);
-
-        } catch (NoPropertyException e) {
-            // If we're here that property is not specified. Just continue using the default
-        }
-
-        try {
-
-            String graphiteServer = getValueFromProperty(GRAPHITE_SERVER_KEY, "Graphite Server URL");
-            int graphitePort = Integer.parseInt(getValueFromProperty(GRAPHITE_PORT_KEY, "Graphite Port"));
-            String graphitePrefix = getValueFromProperty(GRAPHITE_PREFIX_KEY, "Graphite Prefix");
-
-            startGraphiteReporter(metricRegistry, graphiteServer, graphitePort, graphitePrefix, graphiteInterval);
-            startGraphiteReporter(
-                    processMetricRegistry,
-                    graphiteServer,
-                    graphitePort,
-                    graphitePrefix,
-                    graphiteProcessInterval);
-
-        } catch (NumberFormatException e) {
-
-            // thrown because it couldn't parse graphitePort
-            logger.warn("Could not parse Graphite port! Aborting reporting data to Graphite", e);
-
-        } catch (NoPropertyException e) {
-
-            logger.warn("Could not find property required to setup Graphite reporting! Reason: {}", e.getMessage());
-
-        }
-    }
-
-    /**
-     * Reporter of metrics to a Graphite server
-     *
-     * @param host Graphite server
-     * @param port Graphite port (usually 2003)
-     * @param prefix Prefix to use as a namespace for our logs
-     * @param interval interval at which to report metrics to Graphite in seconds
-     */
-    private void startGraphiteReporter(MetricRegistry registry, String host, int port, String prefix, int interval) {
-
-        logger.info("Setting up Graphite reporter");
-
-        Graphite graphite = new Graphite(new InetSocketAddress(host, port));
-
-        GraphiteReporter reporter = GraphiteReporter.forRegistry(registry)
-                .prefixedWith(prefix)
-                .convertRatesTo(TimeUnit.SECONDS)
-                .convertDurationsTo(TimeUnit.MILLISECONDS)
-                .filter(MetricFilter.ALL)
-                .build(graphite);
-
-        reporter.start(interval, TimeUnit.SECONDS);
-    }
-
 }

--- a/src/main/java/org/jboss/pnc/pncmetrics/rest/GeneralRestMetricsFilter.java
+++ b/src/main/java/org/jboss/pnc/pncmetrics/rest/GeneralRestMetricsFilter.java
@@ -20,7 +20,7 @@ package org.jboss.pnc.pncmetrics.rest;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import org.jboss.pnc.pncmetrics.MetricsConfiguration;
+import org.jboss.pnc.pncmetrics.MetricsCDIConfiguration;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -39,7 +39,7 @@ public class GeneralRestMetricsFilter implements ContainerRequestFilter, Contain
     private static final String METRICS_ERROR_KEY = "rest.all.errors";
 
     @Inject
-    private MetricsConfiguration metricsConfiguration;
+    private MetricsCDIConfiguration metricsConfiguration;
 
     @Inject
     private HttpServletRequest servletRequest;

--- a/src/main/java/org/jboss/pnc/pncmetrics/rest/TimedMetricFilter.java
+++ b/src/main/java/org/jboss/pnc/pncmetrics/rest/TimedMetricFilter.java
@@ -20,7 +20,7 @@ package org.jboss.pnc.pncmetrics.rest;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import org.jboss.pnc.pncmetrics.MetricsConfiguration;
+import org.jboss.pnc.pncmetrics.MetricsCDIConfiguration;
 
 import javax.annotation.Priority;
 import javax.inject.Inject;
@@ -51,7 +51,7 @@ public class TimedMetricFilter implements ContainerRequestFilter, ContainerRespo
     private ResourceInfo resourceInfo;
 
     @Inject
-    private MetricsConfiguration metricsConfiguration;
+    private MetricsCDIConfiguration metricsConfiguration;
 
     @Inject
     private HttpServletRequest servletRequest;


### PR DESCRIPTION
We are trying to make sure this library works for both CDI-only apps
(Quarkus), or for apps that support EJBs also (EAP). To do so, I moved
MetricsConfiguration to MetricsCDIConfiguration, and transformed it from
an EJB managed object to a CDI managed object.

Futhermore, MetricsConfiguration is created for EJB managed object. It
injects MetricsCDIConfiguration. They both expose the same public
methods to make sure the shuffle doesn't break anything on the current
projects using it.

CC: @lbossis